### PR TITLE
fix user endpoint to allow non-superusers login

### DIFF
--- a/lib/templates/store/modules/user.js
+++ b/lib/templates/store/modules/user.js
@@ -54,7 +54,7 @@ const actions = {
 
   getInfo({ commit }) {
     return new Promise((resolve, reject) => {
-      const url = process.env.USER_INFO_API || '/api/camomilla/users/current/'
+      const url = process.env.USER_INFO_API || '/api/camomilla/profiles/me/'
       this.$axios.get(url).then(response => {
         commit('SET_INFO', response.data)
         resolve(response.data)


### PR DESCRIPTION
The current endpoint does not allow users not registered as superusers to login since the whole DRF view used for retrieving user data is accessible only to superusers.