### PR TITLE
Added search field on list component

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,15 +10,16 @@ insert_final_newline = true
 
 [*.md]
 indent_style = space
-indent_size = 4
+indent_size = 2
+trim_trailing_whitespace = false
 
 [*.scss]
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 [*.vue]
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 [*.ts]
 indent_style = space
@@ -27,6 +28,3 @@ indent_size = 4
 [*.js]
 indent_style = space
 indent_size = 4
-
-[*.md]
-trim_trailing_whitespace = false

--- a/example/pages/listexample/index.vue
+++ b/example/pages/listexample/index.vue
@@ -6,11 +6,12 @@
           show-select
           :headers="headers"
           :editFields="editFields"
-          :filters="availableFilters" 
+          :filters="availableFilters"
           endpoint="api/camomilla/articles"
           navigable
           addItem
           http
+          searchable
         >
         </List>
       </v-col>


### PR DESCRIPTION
The search field works by listening change events on a `<v-text-field>` with a debounce of 1sec.

Other changes has also been done:
- fixed .editorconfig for correct indentation spaces
- added a debounce of 500ms on `getDataFromApi` calls for preventing components making multiple requests at mount time
- changed layout for data-table's header (quick add button shifted to right), here's a quick screenshot:
![immagine](https://user-images.githubusercontent.com/17519322/143554440-e9d1b733-2570-471a-adce-316dd3de9cba.png)

