### PR TITLE
Customizable dialog of ListQuickEdit

### DIFF
--- a/packages/@mapomodule/uikit/components/List/ListQuickEdit.vue
+++ b/packages/@mapomodule/uikit/components/List/ListQuickEdit.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <slot v-bind="{ on, attrs }" name="activator"></slot>
-    <v-dialog v-model="dialog" width="600" scrollable>
+    <v-dialog v-model="dialog" v-bind="dialogProps">
       <v-card v-bind="$attrs">
         <v-card-title class="pa-0 mb-3">
           <div style="max-width: calc(100% - 40px)">
@@ -152,6 +152,11 @@ export default {
     crud: {
       type: Object,
       required: true,
+    },
+    dialogProps: {
+      type: Object,
+      required: false,
+      default: { width: 600, scrollable: true }
     },
     offline: Boolean,
   },


### PR DESCRIPTION
Added a prop called "dialogProps" in the ListQuickEdit component. This prop is of type object. It is passed to the inner component v-dialog through v-bind.
This prop defaults to the previous hard coded props:
 `width: 600` and `scrollable: true`
This way the component is completely backward compatibile with previous implementations.