### PR TITLE
fix language selector showing in add item detail

### DIFF
--- a/packages/@mapomodule/uikit/components/Detail/Detail.vue
+++ b/packages/@mapomodule/uikit/components/Detail/Detail.vue
@@ -320,7 +320,7 @@ export default {
             return !Object.keys(this.model).length;
         },
         langs() {
-            return this.modelLanguages || this.languages;
+            return this.modelLanguages.length ? this.modelLanguages : this.languages;
         },
         slotBindings() {
             return {


### PR DESCRIPTION
In detail nella creazione di un nuovo elemento non mostrava il selettore per le lingue