### PR TITLE
Fix sortable in online mode data table

### DIFF
--- a/packages/@mapomodule/uikit/components/List/ListTable.vue
+++ b/packages/@mapomodule/uikit/components/List/ListTable.vue
@@ -274,11 +274,7 @@ export default {
       });
     }, 500),
     changeOrder(event){
-      if (this.offlineMode) {
-        const element = this.items[event.oldIndex]
-        this.items.splice(event.oldIndex, 1, )
-        this.items.splice(event.newIndex, 0, element);
-      } else {
+      if (!this.offlineMode) {
         this.crud.update_order(this.items[event.oldIndex][this.lookup], this.items[event.newIndex][this.lookup]).then(
           res => res.reordered && this.getDataFromApi()
         ).catch(error => {
@@ -289,6 +285,9 @@ export default {
           })
         });
       }
+      const element = this.items[event.oldIndex]
+      this.items.splice(event.oldIndex, 1, )
+      this.items.splice(event.newIndex, 0, element);
     },
     setQparams(options) {
       this.$router.push({


### PR DESCRIPTION
SortableJS doesn't automatically update order inside items array, and because mapo links indexes with ids using the same items array it got initially from the first request (even if the `ListTable` has been reordered multiple times) at the end you get a discrepancy from what you save in your DB and what you actually see in `ListTable`. This fix simply reorders items in any case, even if `offlineMode` is disabled.