### PR TITLE
Show correct label in nested tabs

### DIFF
--- a/example/pages/listexample/_detail.vue
+++ b/example/pages/listexample/_detail.vue
@@ -41,6 +41,7 @@ en:
     trash: "Trash"
   pubblicationDate: "Pubblication Date"
   highlightImage: "Highlight Image"
+  testTab: "Test tab en"
 it:
   article: "Articolo"
   identifier: "Identificatore"
@@ -63,6 +64,7 @@ it:
     trash: "Cestinato"
   pubblicationDate: "Data di pubblicazione"
   highlightImage: "Immagine in evidenza"
+  testTab: "Test tab it"
 </i18n>
 
 <script>
@@ -155,12 +157,32 @@ export default {
           {
             // group: "Tabs",
             tabs: {
-              tab_1: [
-                { value: "meta.key1", synci18n: true },
-                { value: "meta.key2", synci18n: true, type: "textarea" },
-              ],
+              tab_1: {
+                tab: { label: this.$t("testTab") },
+                fields: [
+                  { value: "meta.key1", synci18n: true },
+                  { value: "meta.key2", synci18n: true, type: "textarea" },
+                  {
+                    tabs: {
+                      in_tab1: [{ value: "meta.key3", synci18n: true }],
+                      in_tab2: {
+                        tab: { label: "Tab inside tab"},
+                        fields: [{ value: "meta.key4", synci18n: true }],
+                      },
+                    },
+                  },
+                ],
+              },
               tab_2: [{ value: "meta.key2", synci18n: true }],
             },
+          },
+          {
+            // group: "Tabs",
+            group: "Group inside group",
+            fields: [{
+              group: "Group inside group",
+              fields: [{ value: "meta.group_inside_group" }]
+            }]
           },
           { label: this.$t("content"), value: "content", type: "editor" },
           { label: "Color", value: "meta.color", synci18n: true, type: "color" },

--- a/packages/@mapomodule/uikit/components/Form/Form.vue
+++ b/packages/@mapomodule/uikit/components/Form/Form.vue
@@ -8,7 +8,7 @@
       v-show="show(field)"
       :style="show(field, 'visibility') ? '' : 'opacity: 0; visibility: hidden;'"
     >
-    <FormTabs 
+    <FormTabs
         v-if="field.tabs"
         v-model="model"
         v-bind="{ currentLang, errors, languages, readonly }"
@@ -26,7 +26,7 @@
           v-slot:[slot]="props"
         >
           <slot :name="`group.${field.group.slug}.${slot}`" v-bind="props" />
-        </template>    
+        </template>
       </FormTabs>
       <FormGroup
         v-else-if="field.group"
@@ -46,9 +46,9 @@
           v-slot:[slot]="props"
         >
           <slot :name="`group.${field.group.slug}.${slot}`" v-bind="props" />
-        </template>    
+        </template>
       </FormGroup>
-      
+
       <div v-else>
         <slot :name="field.slotName + '.before'" v-bind="{ conf: field, ...slotBindings, }" />
         <slot
@@ -72,7 +72,7 @@
               v-slot:[slot]="props"
             >
               <slot :name="`fields.${field.value}.${slot}`" v-bind="props" />
-            </template>          
+            </template>
           </FormField>
         </slot>
         <slot :name="field.slotName + '.after'" v-bind="{ conf: field, ...slotBindings, }" />
@@ -166,11 +166,9 @@ export default {
     parseTabs(tabs) {
       return Object.keys(tabs).map(key => {
         const tab = tabs[key]
-        return { 
-          label: titleCase(key.replace(/_/, " ")), 
-          slug: key, 
-          ...tab.tab, 
-          fields: this.mapConf(Array.isArray(tab) && tab || tab.fields || []) 
+        return {
+          tab: {label: titleCase(key.replace(/_/, " ")), slug: key, ...tab.tab},
+          fields: this.mapConf(Array.isArray(tab) && tab || tab.fields || [])
         }
       })
     },
@@ -182,7 +180,7 @@ export default {
     mapConf(fields) {
       return fields.map((f, i) =>
         f.tabs
-          ? { group: this.parseTagsGroup(f), tabs: this.parseTabs(f.tabs) } 
+          ? { group: this.parseTagsGroup(f), tabs: this.parseTabs(f.tabs) }
           : f.group
             ? { group: this.parseGroup(f.group), fields: this.mapConf(f.fields) }
             : this.parseConf(f, i)
@@ -191,7 +189,7 @@ export default {
     show(conf, type = "display"){
       const prop = type == "visibility" ? "vVisible" : "vShow"
       if (typeof conf[prop] == "function") {
-        return conf[prop]({ 
+        return conf[prop]({
           model: this.model,
           errors: this.errors,
           languages: this.languages,

--- a/packages/@mapomodule/uikit/components/Form/FormTabs.vue
+++ b/packages/@mapomodule/uikit/components/Form/FormTabs.vue
@@ -12,13 +12,13 @@
       <v-tabs v-model="tabIndex" class="tab-wrapper">
         <v-tab v-for="(tab, index) in conf.tabs" :key="index" v-show="show(tab)">
           <v-badge :value="hasErrors(tab)" color="error" dot>
-            {{ tab.label }} <v-icon v-if="tab.icon">{{ tab.icon }}</v-icon>
+            {{ tab.tab.label }} <v-icon v-if="tab.tab.icon">{{ tab.tab.icon }}</v-icon>
           </v-badge>
         </v-tab>
       </v-tabs>
       <v-tabs-items v-model="tabIndex">
         <v-tab-item v-for="(tab, index) in conf.tabs" :key="index" class="pt-8">
-          <slot :name="`tab.${tab.slug}`" v-bind="slotBindings">
+          <slot :name="`tab.${tab.tab.slug}`" v-bind="slotBindings">
             <Form
               v-model="model"
               v-bind="{ currentLang, errors, languages, readonly }"
@@ -26,19 +26,19 @@
               :moreSlotBindings="slotBindings"
             >
               <template
-                v-for="slot in nameSpacedSlots($slots, `tab.${tab.slug}.`)"
+                v-for="slot in nameSpacedSlots($slots, `tab.${tab.tab.slug}.`)"
                 :slot="slot"
               >
-                <slot :name="`tab.${tab.slug}.${slot}`"></slot>
+                <slot :name="`tab.${tab.tab.slug}.${slot}`"></slot>
               </template>
               <template
                 v-for="slot in nameSpacedSlots(
                   $scopedSlots,
-                  `tab.${tab.slug}.`
+                  `tab.${tab.tab.slug}.`
                 )"
                 v-slot:[slot]="props"
               >
-                <slot :name="`tab.${tab.slug}.${slot}`" v-bind="props" />
+                <slot :name="`tab.${tab.tab.slug}.${slot}`" v-bind="props" />
               </template>
             </Form>
           </slot>
@@ -134,7 +134,7 @@ export default {
     show(conf, type = "display"){
       const prop = type == "visibility" ? "vVisible" : "vShow"
       if (typeof conf[prop] == "function") {
-        return conf[prop]({ 
+        return conf[prop]({
           model: this.model,
           errors: this.errors,
           languages: this.languages,


### PR DESCRIPTION
When using nested tabs or tabs inside groups, tab labels are rendered as 0,1,2... because fields configuration is passed twice on `mapConf`, first time on main `Form` component, second time on nested `Form` component for group (or tab) and so on... and because `mapConf` converts `tabs` object into an array while losing `tab` object (used for label,icon and slug), the ending `Form` component gets tabs as an array and treats keys as indexes, so 0,1,2,3... are showed. With this PR the `tab` object keeps its place into all configurations (parent and child ones) and can be accessed even into nested group/tabs. 