### PR TITLE
fix: componente Repeater

### DIFF
--- a/packages/@mapomodule/uikit/components/Form/fields/Repeater.vue
+++ b/packages/@mapomodule/uikit/components/Form/fields/Repeater.vue
@@ -39,7 +39,6 @@
                 :fields="getFields(model)"
                 :errors="getErrors(index)"
                 :readonly="readonly"
-                immediate
               >
                 <template
                   v-for="(slot, name) in templateSlots(model, $slots)"


### PR DESCRIPTION
Il componente Repeater non aggiorna gli elementi alla delete e al sort quando i gli item sono espansi.
This pull request makes a small update to the `Repeater.vue` form field component by removing the `immediate` attribute from a child component. This change likely affects how or when validation or updates are triggered within the form field.