### PR TITLE
fix(Form): resolve silent data loss in Repeater fields

### DIFF
--- a/packages/@mapomodule/uikit/components/Form/Form.vue
+++ b/packages/@mapomodule/uikit/components/Form/Form.vue
@@ -135,16 +135,13 @@ export default {
     },
   },
   methods: {
-    debouncedEmit: debounce(function (...args) {
-      this.$emit(...args);
-    }, 300),
     nameSpacedSlots,
     initLang(lang = this.currentLang) {
       if (lang && !this.model.translations) {
-        this.model.translations = {};
+        this.$set(this.model, "translations", {});
       }
       if (lang && !this.model.translations[lang]) {
-        this.model.translations[lang] = {};
+        this.$set(this.model.translations, lang, {});
       }
     },
     parseConf(field, i) {
@@ -212,6 +209,9 @@ export default {
     },
   },
   created(){
+    this.debouncedEmit = debounce(function (...args) {
+      this.$emit(...args);
+    }.bind(this), 300);
     this.initLang();
   }
 };

--- a/packages/@mapomodule/uikit/components/Form/FormField.vue
+++ b/packages/@mapomodule/uikit/components/Form/FormField.vue
@@ -71,10 +71,12 @@ export default {
         this.debouncedSetValue(val);
     },
   },
-  methods: {
-    debouncedSetValue: debounce(function (...args) {
+  created() {
+    this.debouncedSetValue = debounce(function (...args) {
       this.setValue(...args);
-    }, 300),
+    }.bind(this), 300);
+  },
+  methods: {
     setValue(val) {
       const old = this.extractValue(this.value);
       setPointed(this.value, this.kpointed, this.accessor.set({ model: this.value, val }));


### PR DESCRIPTION
- Fix shared debounce timer: Move debouncedSetValue (FormField) and debouncedEmit (Form) from methods to created() so each component instance gets its own timer. Previously, all instances shared a single debounce closure via the prototype, causing rapid edits across multiple fields/rows to cancel each other silently.

- Fix non-reactive translations on new Repeater items: Use this.$set() in initLang() instead of direct property assignment, ensuring Vue 2 tracks the translations object reactively from creation.

Context:
Both bugs cause silent data loss — the UI shows the edit, save returns 200, but the API receives stale data because changes never propagated to the parent model.

Bug 1 (shared debounce) is intermittent, worsening with more repeater entries.
Bug 2 (non-reactive translations) is 100% reproducible for non-synci18n fields on newly added repeater items.